### PR TITLE
Mod "HMMWV  VARIANTS PACK" eliminado

### DIFF
--- a/configs/arka_reforger.json
+++ b/configs/arka_reforger.json
@@ -127,11 +127,6 @@
 		"version": "1.2.0"
 	},
 	{
-		"modId": "5D9ECAD071E9ECBC",
-		"name": "HMMWV  VARIANTS PACK",
-		"version": "1.0.43"
-	},
-	{
 		"modId": "5D8D003BC5D829EC",
 		"name": "M2010 Enhanced Sniper Rifle",
 		"version": "1.0.9"


### PR DESCRIPTION
Mod "HMMWV  VARIANTS PACK" eliminado, falta una dependencia de un mod que incluye demasiados vehículos que no necesitamos